### PR TITLE
Formatter, Linter and organize tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ run-server:
 mod:
 	docker-compose exec app go mod tidy
 	docker-compose exec app go mod vendor
+
+fmt:
+	docker-compose exec app go fmt ./...

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+STATICKCHECK_NAME=statickcheck:gomsx
+SQLMIGRATE_NAME=sqlmigrate:gomsx
+SQLBOILER_NAME=sqlboiler:gomsx
+
 migrate-new:
 	docker-compose run --rm migration new ${name}
 
@@ -9,7 +13,7 @@ sqlboiler:
 	docker-compose run --rm sqlboiler mysql --config /sqlboiler.toml
 
 up:
-	docker-compose up -d
+	docker-compose up -d app database
 
 run-server:
 	docker-compose exec app go run app/cmd/main.go
@@ -20,3 +24,35 @@ mod:
 
 fmt:
 	docker-compose exec app go fmt ./...
+
+build-tools:
+	docker build --file ./tools/sqlboiler/Dockerfile --tag $(SQLBOILER_NAME) .
+	docker build --file ./tools/sqlmigrate/Dockerfile --tag $(SQLMIGRATE_NAME) .
+	docker build --file ./tools/staticcheck/Dockerfile --tag $(STATICKCHECK_NAME) .
+
+lint:
+	@docker run\
+		--rm\
+		--volume "$(PWD):/gomsx"\
+		$(STATICKCHECK_NAME) ./...
+
+# "host.docker.internal"がなかなか動かなかったので、localではdocker-composeで行く
+# boiler:
+# 	@docker run\
+# 		--rm\
+# 		--volume "$(PWD)/app/internal/models/v1.0:/sqlboiler"\
+# 		--volume "$(PWD)/tools/sqlboiler/sqlboiler.toml:/sqlboiler.toml"\
+# 		$(SQLBOILER_NAME) mysql --config /sqlboiler.toml
+
+# sqlmigrate-%:
+# 	$(eval CMD:= $*)
+# 	@docker run\
+# 		--rm\
+# 		--volume "$(PWD)/db/migrations:/sqlmigrate/migrations"\
+# 		--volume "$(PWD)/tools/sqlmigrate/dbconfig.yml:/sqlmigrate/dbconfig.yml"\
+# 		--env DB_USER=${DB_USER}\
+# 		--env DB_PASSWORD=${DB_PASSWORD}\
+# 		--env DB_HOST=${DB_HOST}\
+# 		--env DB_NAME=${DB_NAME}\
+# 		--env DB_PORT=${DB_PORT}\
+# 		$(SQLMIGRATE_NAME) $(CMD)

--- a/app/cmd/main.go
+++ b/app/cmd/main.go
@@ -32,7 +32,7 @@ func main() {
 			e.Logger.Fatal(errors.Wrap(err, "Server failure"))
 		}
 	}()
-	
+
 	shutdown.WaitForServerStop(ctx)
 
 	shutdownTaks.ExecuteAll(ctx)

--- a/app/cmd/shutdown/shutdown.go
+++ b/app/cmd/shutdown/shutdown.go
@@ -2,17 +2,17 @@ package shutdown
 
 import (
 	"context"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
-	"log"
 )
 
 var defaultStogSigs = []os.Signal{os.Interrupt, syscall.SIGQUIT, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM}
 
 type Tasks struct {
 	// TODO: define logger interface in app/pkg/log
-	log log.Logger
+	log   log.Logger
 	tasks []Task
 }
 
@@ -23,7 +23,7 @@ type Task interface {
 
 func NewShutdownTasks() *Tasks {
 	return &Tasks{
-		log: log.Logger{},
+		log:   log.Logger{},
 		tasks: make([]Task, 0),
 	}
 }

--- a/app/example/sqlboiler/main.go
+++ b/app/example/sqlboiler/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"log"
 
-	"github.com/jmoiron/sqlx"
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 
 	"github.com/ktakenaka/gomsx/app/internal/models/v1.0/models"

--- a/app/example/sqlboiler/main.go
+++ b/app/example/sqlboiler/main.go
@@ -20,11 +20,17 @@ func main() {
 
 	ctx := context.Background()
 	pilots, err := models.Pilots().All(ctx, db)
+	if err != nil {
+		log.Fatal(err)
+	}
 	log.Println(pilots)
 
 	p := models.Pilot{Name: "hello"}
 	p.Insert(ctx, db, boil.Infer())
 
 	pilots, err = models.Pilots().All(ctx, db)
+	if err != nil {
+		log.Fatal(err)
+	}
 	log.Println(pilots[0].ID)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,17 +55,25 @@ services:
     volumes:
       - ./tools/sqlboiler/sqlboiler.toml:/sqlboiler.toml
       - ./app/internal/models/v1.0:/sqlboiler
+    depends_on:
+      - database
+    # profiles:
+    #   - tools
 
   migration:
     build:
       context: ./tools/sqlmigrate
       dockerfile: Dockerfile
     volumes:
-      - ./tools/sqlmigrate/dbconfig.yml:/db/dbconfig.yml
-      - ./db/migrations:/db/migrations
+      - ./tools/sqlmigrate/dbconfig.yml:/sqlmigrate/dbconfig.yml
+      - ./db/migrations:/sqlmigrate/migrations
     environment:
       DB_USER: *DB_USER
       DB_PASSWORD: *DB_PASSWORD
       DB_HOST: *DB_HOST
       DB_NAME: *DB_NAME
       DB_PORT: 3306
+    depends_on:
+      - database
+    # profiles:
+    #   - tools

--- a/tools/sqlboiler/Dockerfile
+++ b/tools/sqlboiler/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.16.4-alpine
 
+RUN apk update && apk upgrade
+
 WORKDIR /sqlboiler
 RUN go install github.com/volatiletech/sqlboiler/v4@latest &&\
   go install github.com/volatiletech/sqlboiler/v4/drivers/sqlboiler-mysql@latest

--- a/tools/sqlmigrate/Dockerfile
+++ b/tools/sqlmigrate/Dockerfile
@@ -1,7 +1,9 @@
 FROM golang:1.16.4-alpine
 
-WORKDIR /db
-RUN CGO_ENABLED=0 go get -v github.com/rubenv/sql-migrate/...
+RUN apk update && apk upgrade && apk add build-base
+
+WORKDIR /sqlmigrate
+RUN go get -v github.com/rubenv/sql-migrate/...
 
 ENTRYPOINT [ "/go/bin/sql-migrate" ]
 CMD [""]

--- a/tools/sqlmigrate/dbconfig.yml
+++ b/tools/sqlmigrate/dbconfig.yml
@@ -1,5 +1,5 @@
 development:
   dialect: mysql
   datasource: ${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST}:${DB_PORT})/${DB_NAME}?parseTime=true
-  dir: /db/migrations
+  dir: /sqlmigrate/migrations
   table: schema_migrations

--- a/tools/staticcheck/Dockerfile
+++ b/tools/staticcheck/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.16.4-alpine
+
+RUN apk update && && apk upgrade && apk add build-base
+
+WORKDIR /gomsx
+RUN go install honnef.co/go/tools/cmd/staticcheck@latest
+ENTRYPOINT [ "/go/bin/staticcheck" ]
+CMD [ "" ]


### PR DESCRIPTION
# Why
- formatter and linter are necessary
- tools must be executable on local, dev, stg and prod environments

# What
- introduce fmt, lint
- organize tools

# Other information
