### PR TITLE
initialize db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ up:
 	docker-compose up -d app database
 
 run-server:
-	docker-compose exec app go run app/cmd/main.go
+	docker-compose exec app go run app/cmd/main.go -c config/local.yml
 
 mod:
 	docker-compose exec app go mod tidy

--- a/app/cmd/db/db.go
+++ b/app/cmd/db/db.go
@@ -1,0 +1,30 @@
+package db
+
+import (
+	"context"
+
+	"github.com/ktakenaka/gomsx/app/config"
+	"github.com/ktakenaka/gomsx/app/pkg/sqls"
+)
+
+type Task struct {
+	conf *config.DB
+	conn *sqls.DB
+}
+
+func Initialize(ctx context.Context, conf *config.DB) (*Task, error) {
+	db, err := sqls.Connect(conf.SqlsConf())
+	if err != nil {
+		return nil, err
+	}
+
+	return &Task{conf: conf, conn: db}, nil
+}
+
+func (t *Task) Name() string {
+	return "db"
+}
+
+func (t *Task) Shutdown(ctx context.Context) error {
+	return t.conn.Close()
+}

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -3,21 +3,39 @@ package config
 import (
 	"github.com/friendsofgo/errors"
 	"github.com/jinzhu/configor"
+	"github.com/ktakenaka/gomsx/app/pkg/sqls"
 )
 
 type Config struct {
-	Env string `required:"true" env:"ENV"`
+	Env string  `required:"true" env:"ENV"`
+	App *AppCnf `required:"true" yaml:"app"`
+	DB  *DB     `required:"true" yaml:"db"`
+}
 
-	DB struct {
-		Name     string `env:"DB_NAME"`
-		User     string `env:"DB_USER"`
-		Password string `env:"DB_PASSWORD"`
-		Port     uint   `env:"DB_PORT"`
-	}
+type AppCnf struct {
+	ServiceName string `required:"true" yaml:"service_name" default:"gomsx"`
+}
+
+type DB struct {
+	Name     string `env:"DB_NAME"`
+	User     string `env:"DB_USER"`
+	Host     string `env:"DB_HOST"`
+	Password string `env:"DB_PASSWORD"`
+	Port     uint   `env:"DB_PORT"`
 }
 
 func LoadConfig(path string) (*Config, error) {
 	appConfig := Config{}
 	err := configor.Load(&appConfig, path)
 	return &appConfig, errors.Wrapf(err, "failed to load config %s", path)
+}
+
+func (d *DB) SqlsConf() *sqls.Config {
+	return &sqls.Config{
+		Driver:   "mysql",
+		Username: d.Name,
+		Password: d.Password,
+		Host:     d.Host,
+		Port:     d.Port,
+	}
 }

--- a/app/pkg/sqls/config.go
+++ b/app/pkg/sqls/config.go
@@ -1,0 +1,39 @@
+package sqls
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	Driver string
+
+	Username string
+	Password string
+	Host     string
+	Port     uint
+	DBName   string
+
+	MaxIdleConns    int
+	MaxOpenConns    int
+	ConnMaxLifetime time.Duration
+
+	QueryOptions map[string]string
+}
+
+func (c *Config) ToConnString() string {
+	dst := fmt.Sprintf(
+		"%s:%s@tcp(%s:%d)/%s",
+		c.Username, c.Password, c.Host, c.Port, c.DBName,
+	)
+
+	if c.QueryOptions != nil {
+		var options []string
+		for k, v := range c.QueryOptions {
+			options = append(options, k+"="+v)
+		}
+		dst = dst + "?" + strings.Join(options, "&")
+	}
+	return dst
+}

--- a/app/pkg/sqls/sqls.go
+++ b/app/pkg/sqls/sqls.go
@@ -1,0 +1,47 @@
+package sqls
+
+import (
+	"time"
+
+	"github.com/friendsofgo/errors"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+)
+
+const (
+	defaultMaxIdleConns    = 5
+	defaultMaxOpenConns    = 10
+	defaultConnMaxLifetime = 20 * time.Second
+)
+
+type DB struct {
+	*sqlx.DB
+}
+
+func Connect(conf *Config) (*DB, error) {
+	db, err := sqlx.Connect(conf.Driver, conf.ToConnString())
+	// TODO: retry severail times
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to connect to DB")
+	}
+
+	if conf.MaxIdleConns == 0 {
+		db.SetMaxIdleConns(defaultMaxIdleConns)
+	} else {
+		db.SetMaxIdleConns(conf.MaxIdleConns)
+	}
+
+	if conf.MaxOpenConns == 0 {
+		db.SetMaxOpenConns(defaultMaxOpenConns)
+	} else {
+		db.SetMaxOpenConns(conf.MaxOpenConns)
+	}
+
+	if conf.ConnMaxLifetime == 0 {
+		db.SetConnMaxLifetime(defaultConnMaxLifetime)
+	} else {
+		db.SetConnMaxLifetime(conf.ConnMaxLifetime)
+	}
+
+	return &DB{db}, nil
+}

--- a/config/local.yml
+++ b/config/local.yml
@@ -1,2 +1,5 @@
+env: development
 db:
-  name: hello
+  name: gomsx
+app:
+  service_name: gomsx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ x-var: &DB_HOST
   "database"
 x-var: &DB_NAME
   "gomsx"
+x-var: &DB_PORT
+  3306
 
 services:
   app:
@@ -26,6 +28,7 @@ services:
       DB_USER: *DB_USER
       DB_PASSWORD: *DB_PASSWORD
       DB_HOST: *DB_HOST
+      DB_PORT: *DB_PORT
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
# Why
- Open DB connection when initializing the application

# What
- `app/cmd/db/db.go`
  - Create `Task` having DB connection in it
  - In this, convert `app/config` to `pkg/sqls/config`. By doing this, `pkg` can independent from application.
- `app/config/config.go`
  - Load configuration including DB config
- `app/pkg/sqls/sqls.go`
  - Logic to manipulate `sqlx.DB`

# Other information
