### PR TITLE
replace log with pkg/logger

### DIFF
--- a/app/cmd/logger/logger.go
+++ b/app/cmd/logger/logger.go
@@ -1,0 +1,27 @@
+package logger
+
+import (
+	"context"
+
+	"github.com/ktakenaka/gomsx/app/pkg/logger"
+	"github.com/ktakenaka/gomsx/app/pkg/logger/applogger"
+)
+
+type Task struct {
+	AppLogger logger.Logger
+}
+
+func Initialize(ctx context.Context) *Task {
+	// TODO: Change logger based on the environment
+	// 	Like rollbar for prod
+	return &Task{applogger.NewLogger()}
+}
+
+func (t *Task) Name() string {
+	return "logger"
+}
+
+func (t *Task) Shutdown(ctx context.Context) error {
+	logger.CloseLogger(ctx, t.AppLogger)
+	return nil
+}

--- a/app/pkg/logger/applogger/logger.go
+++ b/app/pkg/logger/applogger/logger.go
@@ -1,0 +1,49 @@
+package applogger
+
+import (
+	"context"
+	"log"
+)
+
+// Use just log before deciding logging strategry
+type Logger struct{}
+
+func NewLogger() *Logger {
+	return &Logger{}
+}
+
+func (l *Logger) Error(ctx context.Context, msg string) {
+	log.Println(msg)
+}
+
+func (l *Logger) Errorf(ctx context.Context, format string, args ...interface{}) {
+	log.Printf(format, args...)
+}
+
+func (l *Logger) Info(ctx context.Context, msg string) {
+	log.Println(msg)
+}
+
+func (l *Logger) Infof(ctx context.Context, format string, args ...interface{}) {
+	log.Printf(format, args...)
+}
+
+func (l *Logger) Warn(ctx context.Context, msg string) {
+	log.Println(msg)
+}
+
+func (l *Logger) Warnf(ctx context.Context, format string, args ...interface{}) {
+	log.Printf(format, args...)
+}
+
+func (l *Logger) IsDebugEnabled(ctx context.Context) bool {
+	return true
+}
+
+func (l *Logger) Debug(ctx context.Context, msg string) {
+	log.Println(msg)
+}
+
+func (l *Logger) Debugf(ctx context.Context, format string, args ...interface{}) {
+	log.Printf(format, args...)
+}

--- a/app/pkg/logger/logger.go
+++ b/app/pkg/logger/logger.go
@@ -1,0 +1,41 @@
+package logger
+
+import (
+	"context"
+)
+
+// Logger is interface to log application info
+type Logger interface {
+	// Error prints error log
+	Error(ctx context.Context, msg string)
+	// Errorf prints error log with the specified msg format
+	Errorf(ctx context.Context, format string, args ...interface{})
+
+	// Info prints info log
+	Info(ctx context.Context, msg string)
+	// Infof prints info log with the specified msg format
+	Infof(ctx context.Context, format string, args ...interface{})
+
+	// Warn prints warn log
+	Warn(ctx context.Context, msg string)
+	// Warnf prints warn log with the specified msg format
+	Warnf(ctx context.Context, format string, args ...interface{})
+
+	// IsDebugEnabled checks debug is possible
+	IsDebugEnabled(ctx context.Context) bool
+	// Debug prints debug log
+	Debug(ctx context.Context, msg string)
+	// Debugf prints debug log with the specified msg format
+	Debugf(ctx context.Context, format string, args ...interface{})
+}
+
+type Closer interface {
+	Close(ctx context.Context)
+}
+
+// CloseLogger some of loggers require close, such as Rollbar having a client
+func CloseLogger(ctx context.Context, log Logger) {
+	if c, ok := log.(Closer); ok {
+		c.Close(ctx)
+	}
+}


### PR DESCRIPTION
# Why
- By using interface for logger, it's easy to use another logger based on the environment
  - As using Rollbar on prod

# What
- Define `interface` on `app/pkg/logger`
- Implement `interface` by `app/pkg/logger/applogger`
  - we can implement more beautiful loggers later

# Other information
