### PR TITLE
remove unnecessary command from Dockerfile-dev

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,5 +1,5 @@
 FROM golang:1.16.4-alpine
 
-RUN apk update && apk add --no-cache make && rm -rf /var/cache/apk/*
+RUN apk update && apk upgrade
 
 WORKDIR /go/src


### PR DESCRIPTION
# Why
- It's file for dev

# What
- remove `apk add --no-cache make && rm -rf /var/cache/apk/*`

# Other information
